### PR TITLE
chore(examples): lint and format

### DIFF
--- a/examples/SimpleNetwork.xml
+++ b/examples/SimpleNetwork.xml
@@ -1,9 +1,9 @@
+<?xml version="1.0"?>
 <Lems>
     <ComponentType name="Network">
         <Children name="populations" type="Population"/>
         <Children name="connectivities" type="EventConnectivity"/>
     </ComponentType>
-
 
     <ComponentType name="Population">
         <ComponentReference name="component" type="Component"/>
@@ -13,8 +13,6 @@
         </Structure>
     </ComponentType>
 
-
-
     <ComponentType name="EventConnectivity">
         <Link name="source" type="Population"/>
         <Link name="target" type="Population"/>
@@ -23,17 +21,13 @@
 
     <ComponentType name="ConnectionPattern"/>
 
-
-
     <ComponentType name="AllAll" extends="ConnectionPattern">
         <Structure>
             <ForEach instances="../source" as="a">
                 <ForEach instances="../target" as="b">
                     <EventConnection from="a" to="b"/>
                 </ForEach>
-            </ForEach>    
+            </ForEach>
         </Structure>
-       
     </ComponentType>
-
 </Lems>

--- a/examples/SingleSimulation.xml
+++ b/examples/SingleSimulation.xml
@@ -1,21 +1,17 @@
+<?xml version="1.0"?>
 <Lems>
-
-
     <ComponentType name="Display">
-        <Text name="title"/>   
+        <Text name="title"/>
         <Parameter name="xmin" dimension="none"/>
         <Parameter name="xmax" dimension="none"/>
         <Parameter name="ymin" dimension="none"/>
         <Parameter name="ymax" dimension="none"/>
-
         <Parameter name="timeScale" dimension="time"/>
         <Children name="lines" type="Line"/>
-
         <Simulation>
             <DataDisplay title="title" dataRegion="xmin,xmax,ymin,ymax"/>
         </Simulation>
     </ComponentType>
-
 
     <ComponentType name="Line">
         <Parameter name="scale" dimension="*"/>
@@ -27,19 +23,14 @@
         </Simulation>
     </ComponentType>
 
-
     <ComponentType name="OutputFile">
         <Text name="path"/>
         <Text name="fileName"/>
-	
         <Children name="outputColumn" type="OutputColumn"/>
-	
         <Simulation>
             <DataWriter path="path" fileName="fileName"/>
         </Simulation>
-
     </ComponentType>
-
 
     <ComponentType name="OutputColumn">
         <Path name="quantity"/>
@@ -48,28 +39,17 @@
         </Simulation>
     </ComponentType>
 
-
-
     <ComponentType name="Simulation">
         <Parameter name="length" dimension="time"/>
         <Parameter name="step" dimension="time"/>
-    
         <ComponentReference name="target" type="Component"/>
-
-
         <Children name="displays" type="Display"/>
-       
         <Children name="outputs" type="OutputFile"/>
-   
         <Dynamics>
             <StateVariable name="t" dimension="time"/>
         </Dynamics>
-    
         <Simulation>
             <Run component="target" variable="t" increment="step" total="length"/>
         </Simulation>
     </ComponentType>
-
-
-
 </Lems>

--- a/examples/elecdims.xml
+++ b/examples/elecdims.xml
@@ -1,8 +1,8 @@
+<?xml version="1.0"?>
 <Lems>
     <Dimension name="voltage" m="1" l="2" t="-3" i="-1"/>
     <Dimension name="time" t="1"/>
     <Dimension name="conductance" m="-1" l="-2" t="3" i="2"/>
     <Dimension name="capacitance" m="-1" l="-2" t="4" i="2"/>
     <Dimension name="current" i="1"/>
-    
 </Lems>

--- a/examples/ex2dims.xml
+++ b/examples/ex2dims.xml
@@ -1,5 +1,5 @@
-<Lems> 
-
+<?xml version="1.0"?>
+<Lems>
     <Dimension name="voltage" m="1" l="2" t="-3" i="-1"/>
     <Dimension name="time" t="1"/>
     <Dimension name="per_time" t="-1"/>
@@ -8,8 +8,8 @@
     <Dimension name="current" i="1"/>
     <Dimension name="temperature" k="1"/>
 
-    <Unit symbol="mV" dimension="voltage" power="-3"/> 
-    <Unit symbol="ms" dimension="time" power="-3"/> 
+    <Unit symbol="mV" dimension="voltage" power="-3"/>
+    <Unit symbol="ms" dimension="time" power="-3"/>
     <Unit symbol="pS" dimension="conductance" power="-12"/>
     <Unit symbol="nS" dimension="conductance" power="-9"/>
     <Unit symbol="uF" dimension="capacitance" power="-6"/>
@@ -19,5 +19,4 @@
     <Unit symbol="pA" dimension="current" power="-12"/>
     <Unit symbol="nA" dimension="current" power="-9"/>
     <Unit symbol="degC" dimension="temperature" offset="273.15"/>
-
 </Lems>

--- a/examples/example1.xml
+++ b/examples/example1.xml
@@ -1,275 +1,221 @@
+<?xml version="1.0"?>
 <Lems>
+    <Target component="sim1"/>
 
-    <Target component="sim1" />
-
-    <Dimension name="voltage" m="1" l="2" t="-3" i="-1" />
-    <Dimension name="time" t="1" />
-    <Dimension name="per_time" t="-1" />
-    <Dimension name="conductance" m="-1" l="-2" t="3" i="2" />
-    <Dimension name="capacitance" m="-1" l="-2" t="4" i="2" />
-    <Dimension name="current" i="1" />
-
+    <Dimension name="voltage" m="1" l="2" t="-3" i="-1"/>
+    <Dimension name="time" t="1"/>
+    <Dimension name="per_time" t="-1"/>
+    <Dimension name="conductance" m="-1" l="-2" t="3" i="2"/>
+    <Dimension name="capacitance" m="-1" l="-2" t="4" i="2"/>
+    <Dimension name="current" i="1"/>
 
     <ComponentType name="iaf1">
-        <Parameter name="threshold" dimension="voltage" />
-        <Parameter name="refractoryPeriod" dimension="time" />
-        <Parameter name="capacitance" dimension="capacitance" />
+        <Parameter name="threshold" dimension="voltage"/>
+        <Parameter name="refractoryPeriod" dimension="time"/>
+        <Parameter name="capacitance" dimension="capacitance"/>
     </ComponentType>
 
+    <Unit symbol="mV" dimension="voltage" power="-3"/>
+    <Unit symbol="ms" dimension="time" power="-3"/>
+    <Unit symbol="pS" dimension="conductance" power="-12"/>
+    <Unit symbol="nS" dimension="conductance" power="-9"/>
+    <Unit symbol="uF" dimension="capacitance" power="-6"/>
+    <Unit symbol="nF" dimension="capacitance" power="-9"/>
+    <Unit symbol="pF" dimension="capacitance" power="-12"/>
+    <Unit symbol="per_ms" dimension="per_time" power="3"/>
+    <Unit symbol="pA" dimension="current" power="-12"/>
 
-    <Unit symbol="mV" dimension="voltage" power="-3" />
-    <Unit symbol="ms" dimension="time" power="-3" />
-    <Unit symbol="pS" dimension="conductance" power="-12" />
-    <Unit symbol="nS" dimension="conductance" power="-9" />
-    <Unit symbol="uF" dimension="capacitance" power="-6" />
-    <Unit symbol="nF" dimension="capacitance" power="-9" />
-    <Unit symbol="pF" dimension="capacitance" power="-12" />
-    <Unit symbol="per_ms" dimension="per_time" power="3" />
-    <Unit symbol="pA" dimension="current" power="-12" />
-
-    <iaf1 id="celltype_a" threshold="-30 mV" refractoryPeriod="2 ms" capacitance="3uF" />
+    <iaf1 id="celltype_a" threshold="-30 mV" refractoryPeriod="2 ms" capacitance="3uF"/>
     <!-- or -->
-    <Component id="ctb" type="iaf1" threshold="-30 mV" refractoryPeriod="2 ms" capacitance="1uF" />
-
+    <Component id="ctb" type="iaf1" threshold="-30 mV" refractoryPeriod="2 ms" capacitance="1uF"/>
 
     <ComponentType name="iaf2" extends="iaf1">
-        <Fixed parameter="threshold" value="-45mV" />
+        <Fixed parameter="threshold" value="-45mV"/>
     </ComponentType>
 
     <ComponentType name="iaf3" extends="iaf1">
-        <Parameter name="leakConductance" dimension="conductance" />
-        <Parameter name="leakReversal" dimension="voltage" />
-        <Parameter name="deltaV" dimension="voltage" />
-
-        <EventPort name="spikes-in" direction="in" />
-        <Exposure name="v" dimension="voltage" />
-
+        <Parameter name="leakConductance" dimension="conductance"/>
+        <Parameter name="leakReversal" dimension="voltage"/>
+        <Parameter name="deltaV" dimension="voltage"/>
+        <EventPort name="spikes-in" direction="in"/>
+        <Exposure name="v" dimension="voltage"/>
         <Dynamics>
-            <StateVariable name="v" exposure="v" dimension="voltage" />
-            <TimeDerivative variable="v" value="leakConductance * (leakReversal - v) / capacitance" />
-
+            <StateVariable name="v" exposure="v" dimension="voltage"/>
+            <TimeDerivative variable="v" value="leakConductance * (leakReversal - v) / capacitance"/>
             <OnEvent port="spikes-in">
-                <StateAssignment variable="v" value="v + deltaV" />
+                <StateAssignment variable="v" value="v + deltaV"/>
             </OnEvent>
         </Dynamics>
-
     </ComponentType>
 
-
     <ComponentType name="spikeGenerator">
-        <Parameter name="period" dimension="time" />
-        <EventPort name="a" direction="out" />
-        <Exposure name="tsince" dimension="time" />
+        <Parameter name="period" dimension="time"/>
+        <EventPort name="a" direction="out"/>
+        <Exposure name="tsince" dimension="time"/>
         <Dynamics>
-            <StateVariable name="tsince" exposure="tsince" dimension="time" />
-            <TimeDerivative variable="tsince" value="1" />
+            <StateVariable name="tsince" exposure="tsince" dimension="time"/>
+            <TimeDerivative variable="tsince" value="1"/>
             <OnCondition test="tsince .gt. period">
-                <StateAssignment variable="tsince" value="0" />
-                <EventOut port="a" />
+                <StateAssignment variable="tsince" value="0"/>
+                <EventOut port="a"/>
             </OnCondition>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="spikeGenerator2" extends="spikeGenerator">
         <Dynamics>
-            <StateVariable name="tlast" dimension="time" />
-            <DerivedVariable name="tsince" dimension="time" exposure="tsince" value="t - tlast" />
+            <StateVariable name="tlast" dimension="time"/>
+            <DerivedVariable name="tsince" dimension="time" exposure="tsince" value="t - tlast"/>
             <OnCondition test="t - tlast .gt. period">
-                <StateAssignment variable="tlast" value="t" />
-                <EventOut port="a" />
+                <StateAssignment variable="tlast" value="t"/>
+                <EventOut port="a"/>
             </OnCondition>
         </Dynamics>
     </ComponentType>
 
-
     <ComponentType name="HHRate">
-        <Parameter name="rate" dimension="per_time" />
-        <Parameter name="midpoint" dimension="voltage" />
-        <Parameter name="scale" dimension="voltage" />
-        <Requirement name="v" dimension="voltage" />
-        <Exposure name="r" dimension="per_time" />
+        <Parameter name="rate" dimension="per_time"/>
+        <Parameter name="midpoint" dimension="voltage"/>
+        <Parameter name="scale" dimension="voltage"/>
+        <Requirement name="v" dimension="voltage"/>
+        <Exposure name="r" dimension="per_time"/>
     </ComponentType>
-
 
     <ComponentType name="HHExpRate" extends="HHRate">
         <Dynamics>
-            <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate * exp((v - midpoint)/scale)" />
+            <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate * exp((v - midpoint)/scale)"/>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="HHSigmoidRate" extends="HHRate">
         <Dynamics>
-            <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate / (1 + exp( -(v - midpoint)/scale))" />
+            <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate / (1 + exp( -(v - midpoint)/scale))"/>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="HHExpLinearRate" extends="HHRate">
         <Dynamics>
-            <DerivedVariable name="x" dimension="none" value="(v - midpoint) / scale" />
-            <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate * x / (1 - exp(-x))" />
+            <DerivedVariable name="x" dimension="none" value="(v - midpoint) / scale"/>
+            <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate * x / (1 - exp(-x))"/>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="HHGate0">
-        <Parameter name="power" dimension="none" />
-        <Child name="Forward" type="HHRate" />
-        <Child name="Reverse" type="HHRate" />
-        <Requirement name="v" dimension="voltage" />
-        <Exposure name="fcond" dimension="none" />
+        <Parameter name="power" dimension="none"/>
+        <Child name="Forward" type="HHRate"/>
+        <Child name="Reverse" type="HHRate"/>
+        <Requirement name="v" dimension="voltage"/>
+        <Exposure name="fcond" dimension="none"/>
         <Dynamics>
-            <StateVariable name="q" dimension="none" />
-            <DerivedVariable dimension="per_time" name="rf" select="Forward/r" />
-            <DerivedVariable dimension="per_time" name="rr" select="Reverse/r" />
-            <TimeDerivative variable="q" value="rf * (1 - q) - rr * q" />
-            <DerivedVariable name="fcond" dimension="none" exposure="fcond" value="q^power" />
+            <StateVariable name="q" dimension="none"/>
+            <DerivedVariable dimension="per_time" name="rf" select="Forward/r"/>
+            <DerivedVariable dimension="per_time" name="rr" select="Reverse/r"/>
+            <TimeDerivative variable="q" value="rf * (1 - q) - rr * q"/>
+            <DerivedVariable name="fcond" dimension="none" exposure="fcond" value="q^power"/>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="HHGate">
-        <Parameter name="power" dimension="none" />
-        <Child name="Forward" type="HHRate" />
-        <Child name="Reverse" type="HHRate" />
-        <Requirement name="v" dimension="voltage" />
-        <Exposure name="fcond" dimension="none" />
+        <Parameter name="power" dimension="none"/>
+        <Child name="Forward" type="HHRate"/>
+        <Child name="Reverse" type="HHRate"/>
+        <Requirement name="v" dimension="voltage"/>
+        <Exposure name="fcond" dimension="none"/>
         <Dynamics>
-            <StateVariable name="x" dimension="none" />
-            <DerivedVariable name="ex" dimension="none" value="exp(x)" />
-            <DerivedVariable name="q" dimension="none" value="ex / (1 + ex)" />
-            <DerivedVariable name="rf" dimension="per_time" select="Forward/r" />
-            <DerivedVariable name="rr" dimension="per_time" select="Reverse/r" />
-            <TimeDerivative variable="x" value="(1 + ex)^2 / ex * (rf * (1 - q) - rr * q)" />
-            <DerivedVariable name="fcond" dimension="none" exposure="fcond" value="q^power" />
+            <StateVariable name="x" dimension="none"/>
+            <DerivedVariable name="ex" dimension="none" value="exp(x)"/>
+            <DerivedVariable name="q" dimension="none" value="ex / (1 + ex)"/>
+            <DerivedVariable name="rf" dimension="per_time" select="Forward/r"/>
+            <DerivedVariable name="rr" dimension="per_time" select="Reverse/r"/>
+            <TimeDerivative variable="x" value="(1 + ex)^2 / ex * (rf * (1 - q) - rr * q)"/>
+            <DerivedVariable name="fcond" dimension="none" exposure="fcond" value="q^power"/>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="HHChannel">
-        <Parameter name="conductance" dimension="conductance" />
-        <Children name="gates" type="HHGate" />
-        <Exposure name="g" dimension="conductance" />
+        <Parameter name="conductance" dimension="conductance"/>
+        <Children name="gates" type="HHGate"/>
+        <Exposure name="g" dimension="conductance"/>
         <Dynamics>
-            <DerivedVariable name="gatefeff" dimension="none"
-                             select="gates[*]/fcond" reduce="multiply" />
-            <DerivedVariable name="g" exposure="g"
-                             dimension="conductance" value="conductance * gatefeff" />
+            <DerivedVariable name="gatefeff" dimension="none" select="gates[*]/fcond" reduce="multiply"/>
+            <DerivedVariable name="g" exposure="g" dimension="conductance" value="conductance * gatefeff"/>
         </Dynamics>
     </ComponentType>
-
 
     <HHChannel id="na" conductance="20pS">
         <HHGate id="m" power="3">
-            <Forward type="HHExpLinearRate" rate="1.per_ms"
-                     midpoint="-40mV" scale="10mV" />
-            <Reverse type="HHExpRate" rate="4per_ms" midpoint="-65mV"
-                     scale="-18mV" />
+            <Forward type="HHExpLinearRate" rate="1.per_ms" midpoint="-40mV" scale="10mV"/>
+            <Reverse type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
         </HHGate>
         <HHGate id="h" power="1">
-            <Forward type="HHExpRate" rate="0.07per_ms"
-                     midpoint="-65.mV" scale="-20.mV" />
-            <Reverse type="HHSigmoidRate" rate="1per_ms"
-                     midpoint="-35mV" scale="10mV" />
+            <Forward type="HHExpRate" rate="0.07per_ms" midpoint="-65.mV" scale="-20.mV"/>
+            <Reverse type="HHSigmoidRate" rate="1per_ms" midpoint="-35mV" scale="10mV"/>
         </HHGate>
     </HHChannel>
-
 
     <HHChannel id="k" conductance="20pS">
         <HHGate id="n" power="4">
-            <Forward type="HHExpLinearRate" rate="0.1per_ms"
-                     midpoint="-55mV" scale="10mV" />
-            <Reverse type="HHExpRate" rate="0.125per_ms"
-                     midpoint="-65mV" scale="-80mV" />
+            <Forward type="HHExpLinearRate" rate="0.1per_ms" midpoint="-55mV" scale="10mV"/>
+            <Reverse type="HHExpRate" rate="0.125per_ms" midpoint="-65mV" scale="-80mV"/>
         </HHGate>
     </HHChannel>
 
-
     <ComponentType name="ChannelPopulation">
-        <ComponentReference name="channel" type="HHChannel" />
-        <Parameter name="number" dimension="none" />
-        <Parameter name="erev" dimension="voltage" />
-        <Requirement name="v" dimension="voltage" />
-        <Exposure name="current" dimension="current" />
-
+        <ComponentReference name="channel" type="HHChannel"/>
+        <Parameter name="number" dimension="none"/>
+        <Parameter name="erev" dimension="voltage"/>
+        <Requirement name="v" dimension="voltage"/>
+        <Exposure name="current" dimension="current"/>
         <Dynamics>
-            <DerivedVariable name="channelg" dimension="conductance" select="channel/g" />
-            <DerivedVariable name="geff" dimension="conductance" value="channelg * number" />
-            <DerivedVariable name="current" dimension="current" exposure="current" value="geff * (erev - v)" />
+            <DerivedVariable name="channelg" dimension="conductance" select="channel/g"/>
+            <DerivedVariable name="geff" dimension="conductance" value="channelg * number"/>
+            <DerivedVariable name="current" dimension="current" exposure="current" value="geff * (erev - v)"/>
         </Dynamics>
-
         <Structure>
-            <ChildInstance component="channel" />
+            <ChildInstance component="channel"/>
         </Structure>
     </ComponentType>
 
-
-
     <ComponentType name="HHCell">
-        <Parameter name="capacitance" dimension="capacitance" />
-        <Children name="populations" type="ChannelPopulation" />
-        <Parameter name="injection" dimension="current" />
-        <Parameter name="v0" dimension="voltage" />
-        <Exposure name="v" dimension="voltage" />
+        <Parameter name="capacitance" dimension="capacitance"/>
+        <Children name="populations" type="ChannelPopulation"/>
+        <Parameter name="injection" dimension="current"/>
+        <Parameter name="v0" dimension="voltage"/>
+        <Exposure name="v" dimension="voltage"/>
         <Dynamics>
             <OnStart>
-                <StateAssignment variable="v" value="v0" />
+                <StateAssignment variable="v" value="v0"/>
             </OnStart>
-
-            <DerivedVariable name="totcurrent"
-                             dimension="current" select="populations[*]/current"
-                             reduce="add" />
-            <StateVariable name="v" exposure="v"
-                           dimension="voltage" />
-            <TimeDerivative variable="v"
-                            value="(totcurrent + injection) / capacitance" />
+            <DerivedVariable name="totcurrent" dimension="current" select="populations[*]/current" reduce="add"/>
+            <StateVariable name="v" exposure="v" dimension="voltage"/>
+            <TimeDerivative variable="v" value="(totcurrent + injection) / capacitance"/>
         </Dynamics>
     </ComponentType>
 
-
-
     <HHCell id="hhcell_1" capacitance="1pF" injection="4pA" v0="-60mV">
-        <ChannelPopulation channel="na" number="6000"  erev="50mV" />
-        <ChannelPopulation channel="k" number="1800" erev="-77mV" />
+        <ChannelPopulation channel="na" number="6000" erev="50mV"/>
+        <ChannelPopulation channel="k" number="1800" erev="-77mV"/>
     </HHCell>
-
-
-    <Component id="celltype_c" type="iaf3" leakConductance="3 pS" refractoryPeriod="3 ms" threshold="45 mV" leakReversal="-50 mV" deltaV="5mV" capacitance="1uF" />
-
-    <Component id="gen1" type="spikeGenerator" period="30ms" />
-
-    <Component id="gen2" type="spikeGenerator2" period="32ms" />
-
-    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS" refractoryPeriod="4ms" capacitance="1pF" />
-
-
-    <Include file="SimpleNetwork.xml" />
-
-
+    <Component id="celltype_c" type="iaf3" leakConductance="3 pS" refractoryPeriod="3 ms" threshold="45 mV" leakReversal="-50 mV" deltaV="5mV" capacitance="1uF"/>
+    <Component id="gen1" type="spikeGenerator" period="30ms"/>
+    <Component id="gen2" type="spikeGenerator2" period="32ms"/>
+    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS" refractoryPeriod="4ms" capacitance="1pF"/>
+    <Include file="SimpleNetwork.xml"/>
     <Network id="net1">
-        <Population id="p1" component="gen1" size="1" />
-        <Population id="p2" component="gen2" size="1" />
-        <Population id="p3" component="iaf3cpt" size="1" />
-
-        <Population id="hhpop" component="hhcell_1" size="1" />
-
+        <Population id="p1" component="gen1" size="1"/>
+        <Population id="p2" component="gen2" size="1"/>
+        <Population id="p3" component="iaf3cpt" size="1"/>
+        <Population id="hhpop" component="hhcell_1" size="1"/>
         <EventConnectivity id="p1-p3" source="p1" target="p3">
-            <Connections type="AllAll" />
+            <Connections type="AllAll"/>
         </EventConnectivity>
     </Network>
-
-
-    <Include file="SingleSimulation.xml" />
-    
+    <Include file="SingleSimulation.xml"/>
     <Simulation id="sim1" length="80ms" step="0.01ms" target="net1">
-        <Display id="d0" title="Example 1: Dimensions, Units, ComponentTypes and Components" 
-                 timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
-            <Line id="tsince" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#00c000" />
-            <Line id="p3v" quantity="p3[0]/v" scale="1mV" timeScale="1ms" color="#0000f0" />
-            <Line id="p0v" quantity="hhpop[0]/v" scale="1mV" timeScale="1ms" color="#ff4040" />
+        <Display id="d0" title="Example 1: Dimensions, Units, ComponentTypes and Components" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
+            <Line id="tsince" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#00c000"/>
+            <Line id="p3v" quantity="p3[0]/v" scale="1mV" timeScale="1ms" color="#0000f0"/>
+            <Line id="p0v" quantity="hhpop[0]/v" scale="1mV" timeScale="1ms" color="#ff4040"/>
         </Display>
     </Simulation>
-
 </Lems>

--- a/examples/example2.xml
+++ b/examples/example2.xml
@@ -1,51 +1,41 @@
+<?xml version="1.0"?>
 <Lems>
- 
     <Target component="sim1"/>
- 
+
     <Include file="ex2dims.xml"/>
-    <Include file="hhchannel.xml"/> 
- 
+    <Include file="hhchannel.xml"/>
     <Include file="hhcell.xml"/>
     <Include file="spikegenerators.xml"/>
     <Include file="hhmodels.xml"/>
-    <Include file="misciaf.xml"/> 
-
+    <Include file="misciaf.xml"/>
     <Include file="SimpleNetwork.xml"/>
 
     <HHCell id="hhcell_1" capacitance="1pF" injection="4pA" v0="-60mV">
         <ChannelPopulation channel="na" number="6000" erev="50mV"/>
         <ChannelPopulation channel="k" number="1800" erev="-77mV"/>
     </HHCell>
- 
+
     <Component id="gen1" type="spikeGenerator" period="30ms"/>
-
     <Component id="gen2" type="spikeGenerator2" period="32ms"/>
-
-    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS"
-           refractoryPeriod="4ms" capacitance="1pF"/>
-
+    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS" refractoryPeriod="4ms" capacitance="1pF"/>
 
     <Network id="net1">
         <Population id="p1" component="gen1" size="1"/>
         <Population id="p2" component="gen2" size="1"/>
         <Population id="p3" component="iaf3cpt" size="1"/>
-   
         <Population id="hhpop" component="hhcell_1" size="1"/>
-    
-   
         <EventConnectivity id="p1-p3" source="p1" target="p3">
             <Connections type="AllAll"/>
         </EventConnectivity>
     </Network>
-    
-    <Include file="SingleSimulation.xml" />
-    
+
+    <Include file="SingleSimulation.xml"/>
+
     <Simulation id="sim1" length="80ms" step="0.01ms" target="net1">
         <Display id="d0" title="Example 2" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
-            <Line id="tsince" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#00c000" />
-            <Line id="p3v" quantity="p3[0]/v" scale="1mV" timeScale="1ms" color="#0000f0" />
-            <Line id="p0v" quantity="hhpop[0]/v" scale="1mV" timeScale="1ms" color="#ff4040" />
+            <Line id="tsince" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#00c000"/>
+            <Line id="p3v" quantity="p3[0]/v" scale="1mV" timeScale="1ms" color="#0000f0"/>
+            <Line id="p0v" quantity="hhpop[0]/v" scale="1mV" timeScale="1ms" color="#ff4040"/>
         </Display>
     </Simulation>
-
 </Lems>

--- a/examples/example3.xml
+++ b/examples/example3.xml
@@ -1,20 +1,13 @@
+<?xml version="1.0"?>
 <Lems>
- 
-    <Target component="sim1"/> 
- 
+    <Target component="sim1"/>
     <Include file="ex2dims.xml"/>
-
     <Include file="spikegenerators.xml"/>
-  
     <Include file="misciaf.xml"/>
- 
 
-    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS"
-           refractoryPeriod="4ms" capacitance="1pF"/>
- 
+    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS" refractoryPeriod="4ms" capacitance="1pF"/>
     <Component id="gena" type="spikeGenerator2" period="32ms"/>
     <Component id="genb" type="spikeGenerator2" period="40ms"/>
-
 
     <ComponentType name="Synapse">
         <Parameter name="deltaG" dimension="conductance"/>
@@ -23,98 +16,75 @@
         <EventPort name="in" direction="in"/>
         <Requirement name="v" dimension="voltage"/>
         <Exposure name="current" dimension="current"/>
-    
         <Dynamics>
             <StateVariable name="geff" dimension="conductance"/>
             <TimeDerivative variable="geff" value="-geff / tfall"/>
-       
             <OnStart>
                 <StateAssignment variable="geff" value="0"/>
             </OnStart>
-
             <OnEvent port="in">
                 <StateAssignment variable="geff" value="geff + deltaG"/>
-            </OnEvent>     
-        
+            </OnEvent>
             <DerivedVariable name="current" exposure="current" dimension="current" value="geff * (erev - v)"/>
         </Dynamics>
     </ComponentType>
 
+    <Synapse id="sy1" deltaG="30pS" erev="50mV" tfall="10ms"/>
 
-    <Synapse id="sy1" deltaG="30pS" erev="50mV"  tfall="10ms"/>
-
-    
     <ComponentType name="Cell"/>
- 
-    
+
     <ComponentType name="synapseCell" extends="Cell">
         <Parameter name="capacitance" dimension="capacitance"/>
         <Parameter name="leakConductance" dimension="conductance"/>
         <Parameter name="leakReversal" dimension="voltage"/>
         <Exposure name="v" dimension="voltage"/>
         <Attachments name="synapses" type="Synapse"/>
-    
         <Dynamics>
             <StateVariable name="v" dimension="voltage" exposure="v"/>
             <DerivedVariable name="synapticCurrent" dimension="current" select="synapses[*]/current" reduce="add"/>
             <TimeDerivative variable="v" value="(leakConductance * (leakReversal - v) + synapticCurrent) / capacitance"/>
         </Dynamics>
-
     </ComponentType>
 
-    <synapseCell id="sycell" leakReversal="-50mV"  leakConductance="50pS"  capacitance="1pF"/>
-
+    <synapseCell id="sycell" leakReversal="-50mV" leakConductance="50pS" capacitance="1pF"/>
 
     <ComponentType name="ExplicitNetwork">
         <Children name="populations" type="Population"/>
         <Children name="connections" type="ExplicitConnection"/>
     </ComponentType>
 
-
     <ComponentType name="Population">
         <ComponentReference name="component" type="Component"/>
         <Parameter name="size" dimension="none"/>
-   
         <Structure>
             <MultiInstantiate number="size" component="component"/>
         </Structure>
-    
     </ComponentType>
-  
-  
+
     <ComponentType name="ExplicitConnection">
         <Path name="from"/>
         <Path name="to"/>
-     
         <ComponentReference name="synapse" type="Synapse"/>
-      
         <Text name="destination"/>
         <Text name="sourcePort"/>
         <Text name="targetPort"/>
         <Structure>
             <With instance="from" as="a"/>
             <With instance="to" as="b"/>
-            <EventConnection from="a" to="b"
-                          receiver="synapse" receiverContainer="destination" 
-                          sourcePort="sourcePort" targetPort="targetPort"/>
-        
+            <EventConnection from="a" to="b" receiver="synapse" receiverContainer="destination" sourcePort="sourcePort" targetPort="targetPort"/>
         </Structure>
     </ComponentType>
-
 
     <ExplicitNetwork id="net1">
         <Population id="p1" component="gena" size="1"/>
         <Population id="p2" component="genb" size="1"/>
         <Population id="p3" component="sycell" size="3"/>
-    
         <ExplicitConnection from="p1[0]" to="p3[0]" synapse="sy1"/>
         <ExplicitConnection from="p2[0]" to="p3[1]" synapse="sy1"/>
     </ExplicitNetwork>
 
-  
- 
-    <Include file="SingleSimulation.xml" />
-    
+    <Include file="SingleSimulation.xml"/>
+
     <Simulation id="sim1" length="80ms" step="0.01ms" target="net1">
         <Display id="d0" title="Example 3: User defined types for networks and populations" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
             <Line id="gen0_tsince" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#a0a000"/>
@@ -123,7 +93,4 @@
             <Line id="c1_v" quantity="p3[1]/v" scale="1mV" timeScale="1ms" color="#0000f0"/>
         </Display>
     </Simulation>
-  
-  
-
 </Lems>

--- a/examples/example4.xml
+++ b/examples/example4.xml
@@ -1,46 +1,36 @@
+<?xml version="1.0"?>
 <Lems>
-
     <Target component="sim1"/>
 
     <Include file="ex2dims.xml"/>
-   
-    
+
     <ComponentType name="KSChannel">
         <Parameter name="conductance" dimension="conductance"/>
         <Children name="gates" type="KSGate"/>
         <Exposure name="g" dimension="conductance"/>
-    
         <Dynamics>
             <DerivedVariable name="fopen" dimension="none" select="gates[*]/fopen" reduce="multiply"/>
             <DerivedVariable name="g" exposure="g" dimension="conductance" value="fopen * conductance"/>
         </Dynamics>
     </ComponentType>
 
-
-    
     <ComponentType name="KSGate">
         <Parameter name="power" dimension="none"/>
         <Parameter name="deltaV" dimension="voltage"/>
         <Children name="states" type="KSState"/>
         <Children name="transitions" type="KSTransition"/>
         <Exposure name="fopen" dimension="none"/>
-    
         <Dynamics>
-            <KineticScheme name="ks" nodes="states" stateVariable="occupancy"
-                         edges="transitions" edgeSource="from" edgeTarget="to" 
-                         forwardRate="rf" reverseRate="rr"/>
-       
+            <KineticScheme name="ks" nodes="states" stateVariable="occupancy" edges="transitions" edgeSource="from" edgeTarget="to" forwardRate="rf" reverseRate="rr"/>
             <DerivedVariable name="q" dimension="none" select="states[*]/q" reduce="add"/>
             <DerivedVariable name="fopen" exposure="fopen" dimension="none" value="q^power"/>
         </Dynamics>
     </ComponentType>
 
-    
     <ComponentType name="KSState">
         <Parameter name="relativeConductance" dimension="none"/>
         <Exposure name="q" dimension="none"/>
         <Exposure name="occupancy" dimension="none"/>
-    
         <Dynamics>
             <StateVariable name="occupancy" exposure="occupancy" dimension="none"/>
             <DerivedVariable name="q" exposure="q" value="relativeConductance * occupancy"/>
@@ -51,11 +41,9 @@
         <Fixed parameter="relativeConductance" value="0"/>
     </ComponentType>
 
-
     <ComponentType name="KSOpenState" extends="KSState">
         <Fixed parameter="relativeConductance" value="1"/>
     </ComponentType>
-
 
     <ComponentType name="KSTransition">
         <Link name="from" type="KSState"/>
@@ -64,7 +52,6 @@
         <Exposure name="rr" dimension="per_time"/>
     </ComponentType>
 
-
     <ComponentType name="VHalfTransition" extends="KSTransition">
         <Parameter name="vHalf" dimension="voltage"/>
         <Parameter name="z" dimension="none"/>
@@ -72,8 +59,7 @@
         <Parameter name="tau" dimension="time"/>
         <Parameter name="tauMin" dimension="time"/>
         <Constant name="kte" dimension="voltage" value="25.3mV"/>
-        <Requirement name="v" dimension="voltage"/>  
-   
+        <Requirement name="v" dimension="voltage"/>
         <Dynamics>
             <DerivedVariable name="rf0" dimension="per_time" value="exp(z * gamma * (v - vHalf) / kte) / tau"/>
             <DerivedVariable name="rr0" dimension="per_time" value="exp(-z * (1 - gamma) * (v - vHalf) / kte) / tau"/>
@@ -82,31 +68,25 @@
         </Dynamics>
     </ComponentType>
 
-
-
     <KSChannel id="na1" conductance="20pS">
         <KSGate id="m" power="1" deltaV="0.1mV">
             <KSClosedState id="c1"/>
             <KSClosedState id="c2"/>
             <KSOpenState id="o1" relativeConductance="1"/>
             <KSClosedState id="c3"/>
-            <VHalfTransition from="c1" to="c2" vHalf = "-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
-            <VHalfTransition from="c2" to="o1" vHalf = "-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
-            <VHalfTransition from="o1" to="c3" vHalf = "-70mV" z="1.1" gamma="0.90" tau="8.0ms" tauMin="0.01ms"/>         
+            <VHalfTransition from="c1" to="c2" vHalf="-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
+            <VHalfTransition from="c2" to="o1" vHalf="-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
+            <VHalfTransition from="o1" to="c3" vHalf="-70mV" z="1.1" gamma="0.90" tau="8.0ms" tauMin="0.01ms"/>
         </KSGate>
     </KSChannel>
-
 
     <KSChannel id="k1" conductance="30pS">
         <KSGate id="n" power="1" deltaV="0.1mV">
             <KSClosedState id="c1"/>
             <KSOpenState id="o1"/>
-            <VHalfTransition from="c1" to="o1" vHalf = "0mV" z="1.5" gamma="0.75" tau="3.2ms" tauMin="0.3ms"/>
+            <VHalfTransition from="c1" to="o1" vHalf="0mV" z="1.5" gamma="0.75" tau="3.2ms" tauMin="0.3ms"/>
         </KSGate>
     </KSChannel>
-
-
-
 
     <ComponentType name="ChannelPopulation">
         <ComponentReference name="channel" type="KSChannel"/>
@@ -114,20 +94,15 @@
         <Parameter name="erev" dimension="voltage"/>
         <Requirement name="v" dimension="voltage"/>
         <Exposure name="current" dimension="current"/>
-    
         <Dynamics>
             <DerivedVariable name="channelg" dimension="conductance" select="channel/g"/>
             <DerivedVariable name="geff" value="channelg * number"/>
             <DerivedVariable name="current" exposure="current" dimension="current" value="geff * (erev - v)"/>
-        </Dynamics>    
-    
-        <Structure>    
-            <ChildInstance component="channel"/>    
+        </Dynamics>
+        <Structure>
+            <ChildInstance component="channel"/>
         </Structure>
     </ComponentType>
-
-
-
 
     <ComponentType name="KSCell">
         <Parameter name="capacitance" dimension="capacitance"/>
@@ -139,24 +114,19 @@
             <OnStart>
                 <StateAssignment variable="v" value="v0"/>
             </OnStart>
-  
             <DerivedVariable name="totcurrent" dimension="current" select="populations[*]/current" reduce="add"/>
-            <StateVariable name="v" exposure="v" dimension="voltage"/> 
+            <StateVariable name="v" exposure="v" dimension="voltage"/>
             <TimeDerivative variable="v" value="(totcurrent + injection) / capacitance"/>
         </Dynamics>
     </ComponentType>
-
-
 
     <KSCell id="kscell_1" capacitance="0.5pF" injection="0.1pA" v0="-60mV">
         <ChannelPopulation id="pna" channel="na1" number="400" erev="50mV"/>
         <ChannelPopulation id="pk" channel="k1" number="180" erev="-77mV"/>
     </KSCell>
 
-  
- 
-    <Include file="SingleSimulation.xml" />
-    
+    <Include file="SingleSimulation.xml"/>
+
     <Simulation id="sim1" length="80ms" step="0.05ms" target="kscell_1">
         <Display id="d0" title="Example 4: Kinetic Schemes" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
             <Line id="v" quantity="v" scale="1mV" timeScale="1ms" color="#0000f0"/>
@@ -165,15 +135,11 @@
             <Line id="K channel - c1" quantity="pk/k1/n/c1/occupancy" scale="1" timeScale="1ms" color="#fffff0"/>
             <Line id="K channel - o1 (=n)" quantity="pk/k1/n/o1/occupancy" scale="1" timeScale="1ms" color="#f00000"/>
         </Display>
-            
         <Display id="d2" title="Example 4: Kinetic Schemes: Na channel states" timeScale="1ms" xmin="-10" xmax="90" ymin="-.1" ymax="1.1">
             <Line id="Na channel - c1" quantity="pna/na1/m/c1/occupancy" scale="1" timeScale="1ms" color="#fffff0"/>
             <Line id="Na channel - c2" quantity="pna/na1/m/c2/occupancy" scale="1" timeScale="1ms" color="#f00000"/>
             <Line id="Na channel - c3" quantity="pna/na1/m/c3/occupancy" scale="1" timeScale="1ms" color="#000ff0"/>
             <Line id="Na channel - o1 (=m)" quantity="pna/na1/m/o1/occupancy" scale="1" timeScale="1ms" color="#ffff33"/>
         </Display>
-        
     </Simulation>
-
-
 </Lems>

--- a/examples/example5.xml
+++ b/examples/example5.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0"?>
 <Lems>
-
     <Target component="sim1"/>
 
     <Include file="ex2dims.xml"/>
@@ -9,11 +9,9 @@
         <Parameter name="charge" dimension="none"/>
     </ComponentType>
 
-
     <ComponentType name="Environment">
         <Children name="membranePotentials" type="MembranePotential"/>
     </ComponentType>
-
 
     <ComponentType name="MembranePotential">
         <ComponentReference name="species" type="Species"/>
@@ -24,50 +22,39 @@
     <Species id="K" name="Potassium" charge="1"/>
     <Species id="Ca" name="Calcium" charge="1"/>
 
-
     <Environment id="env1">
         <MembranePotential species="Na" reversal="50mV"/>
-        <MembranePotential species="K" reversal="-80mV"/>    
+        <MembranePotential species="K" reversal="-80mV"/>
     </Environment>
-
 
     <ComponentType name="KSChannel">
         <Parameter name="conductance" dimension="conductance"/>
         <ComponentReference name="species" type="Species"/>
         <Children name="gates" type="KSGate"/>
         <Exposure name="g" dimension="conductance"/>
-    
         <Dynamics>
             <DerivedVariable name="fopen" dimension="none" select="gates[*]/fopen" reduce="multiply"/>
             <DerivedVariable name="g" exposure="g" dimension="conductance" value="fopen * conductance"/>
         </Dynamics>
     </ComponentType>
 
-
-    
     <ComponentType name="KSGate">
         <Parameter name="power" dimension="none"/>
         <Parameter name="deltaV" dimension="voltage"/>
         <Children name="states" type="KSState"/>
         <Children name="transitions" type="KSTransition"/>
         <Exposure name="fopen" dimension="none"/>
-    
-        <Dynamics>   
-            <KineticScheme name="ks" nodes="states" stateVariable="occupancy"
-                           edges="transitions" edgeSource="from" edgeTarget="to" 
-                           forwardRate="rf" reverseRate="rr" dependency="v" step="deltaV"/>
-    
+        <Dynamics>
+            <KineticScheme name="ks" nodes="states" stateVariable="occupancy" edges="transitions" edgeSource="from" edgeTarget="to" forwardRate="rf" reverseRate="rr" dependency="v" step="deltaV"/>
             <DerivedVariable name="q" dimension="none" select="states[*]/q" reduce="add"/>
             <DerivedVariable name="fopen" exposure="fopen" dimension="none" value="q^power"/>
         </Dynamics>
     </ComponentType>
 
-    
     <ComponentType name="KSState">
         <Parameter name="relativeConductance" dimension="none"/>
         <Exposure name="q" dimension="none"/>
         <Exposure name="occupancy" dimension="none"/>
-   
         <Dynamics>
             <StateVariable name="occupancy" exposure="occupancy" dimension="none"/>
             <DerivedVariable name="q" exposure="q" value="relativeConductance * occupancy"/>
@@ -78,20 +65,16 @@
         <Fixed parameter="relativeConductance" value="0"/>
     </ComponentType>
 
-
     <ComponentType name="KSOpenState" extends="KSState">
         <Fixed parameter="relativeConductance" value="1"/>
     </ComponentType>
-
 
     <ComponentType name="KSTransition">
         <Link name="from" type="KSState"/>
         <Link name="to" type="KSState"/>
         <Exposure name="rf" dimension="per_time"/>
         <Exposure name="rr" dimension="per_time"/>
- 
     </ComponentType>
-
 
     <ComponentType name="VHalfTransition" extends="KSTransition">
         <Parameter name="vHalf" dimension="voltage"/>
@@ -100,8 +83,7 @@
         <Parameter name="tau" dimension="time"/>
         <Parameter name="tauMin" dimension="time"/>
         <Constant name="kte" dimension="voltage" value="25.3mV"/>
-        <Requirement name="v" dimension="voltage"/>  
-    
+        <Requirement name="v" dimension="voltage"/>
         <Dynamics>
             <DerivedVariable name="rf0" dimension="per_time" value="exp(z * gamma * (v - vHalf) / kte) / tau"/>
             <DerivedVariable name="rr0" dimension="per_time" value="exp(-z * (1 - gamma) * (v - vHalf) / kte) / tau"/>
@@ -110,34 +92,25 @@
         </Dynamics>
     </ComponentType>
 
-
-
-
-
-
     <KSChannel id="na1" conductance="20pS" species="Na">
         <KSGate power="1" deltaV="0.1mV">
             <KSClosedState id="c1"/>
             <KSClosedState id="c2"/>
             <KSOpenState id="o1" relativeConductance="1"/>
             <KSClosedState id="c3"/>
-            <VHalfTransition from="c1" to="c2" vHalf = "-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
-            <VHalfTransition from="c2" to="o1" vHalf = "-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
-            <VHalfTransition from="o1" to="c3" vHalf = "-70mV" z="1.1" gamma="0.90" tau="8.0ms" tauMin="0.01ms"/>         
+            <VHalfTransition from="c1" to="c2" vHalf="-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
+            <VHalfTransition from="c2" to="o1" vHalf="-35mV" z="2.5" gamma="0.8" tau="0.15ms" tauMin="0.001ms"/>
+            <VHalfTransition from="o1" to="c3" vHalf="-70mV" z="1.1" gamma="0.90" tau="8.0ms" tauMin="0.01ms"/>
         </KSGate>
     </KSChannel>
-
 
     <KSChannel id="k1" conductance="30pS" species="K">
         <KSGate power="1" deltaV="0.1mV">
             <KSClosedState id="c1"/>
             <KSOpenState id="o1"/>
-            <VHalfTransition from="c1" to="o1" vHalf = "0mV" z="1.5" gamma="0.75" tau="3.2ms" tauMin="0.3ms"/>
+            <VHalfTransition from="c1" to="o1" vHalf="0mV" z="1.5" gamma="0.75" tau="3.2ms" tauMin="0.3ms"/>
         </KSGate>
     </KSChannel>
-
-
-
 
     <ComponentType name="ChannelPopulation">
         <ComponentReference name="channel" type="KSChannel"/>
@@ -146,20 +119,14 @@
         <Exposure name="current" dimension="current"/>
         <DerivedParameter name="erev" dimension="voltage" select="//MembranePotential[species=channel/species]/reversal"/>
         <Dynamics>
-     
             <DerivedVariable name="channelg" dimension="conductance" select="channel/g"/>
             <DerivedVariable name="geff" value="channelg * number"/>
             <DerivedVariable name="current" exposure="current" value="geff * (erev - v)"/>
-        </Dynamics>    
-    
-    
-        <Structure>    
-            <ChildInstance component="channel"/>    
+        </Dynamics>
+        <Structure>
+            <ChildInstance component="channel"/>
         </Structure>
     </ComponentType>
-
-
-
 
     <ComponentType name="KSCell">
         <Parameter name="capacitance" dimension="capacitance"/>
@@ -172,27 +139,22 @@
             <OnStart>
                 <StateAssignment variable="v" value="v0"/>
             </OnStart>
-  
             <DerivedVariable name="totcurrent" dimension="current" select="populations[*]/current" reduce="add"/>
-            <StateVariable name="v" exposure="v" dimension="voltage"/> 
+            <StateVariable name="v" exposure="v" dimension="voltage"/>
             <TimeDerivative variable="v" value="(totcurrent + injection) / capacitance"/>
         </Dynamics>
     </ComponentType>
-
-
 
     <KSCell id="kscell_1" capacitance="0.4pF" injection="1pA" v0="-60mV" environment="env1">
         <ChannelPopulation channel="na1" number="400"/>
         <ChannelPopulation channel="k1" number="180"/>
     </KSCell>
 
-    
-    <Include file="SingleSimulation.xml" />
-    
+    <Include file="SingleSimulation.xml"/>
+
     <Simulation id="sim1" length="80ms" step="0.05ms" target="kscell_1">
         <Display id="d0" title="Example 5: References and paths" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
             <Line id="v" quantity="v" scale="1mV" timeScale="1ms" color="#0000f0"/>
         </Display>
     </Simulation>
-
 </Lems>

--- a/examples/example6.xml
+++ b/examples/example6.xml
@@ -1,43 +1,35 @@
+<?xml version="1.0"?>
 <Lems>
- 
-    <Target component="sim1"/> 
- 
+    <Target component="sim1"/>
+
     <Include file="ex2dims.xml"/>
-    <Include file="hhchannel.xml"/> 
- 
+    <Include file="hhchannel.xml"/>
     <Include file="hhcell.xml"/>
     <Include file="spikegenerators.xml"/>
     <Include file="hhmodels.xml"/>
     <Include file="misciaf.xml"/>
- 
 
     <HHCell id="hhcell_1" capacitance="1pF" injection="4pA" v0="-60mV">
         <ChannelPopulation id="NaPop" channel="na" number="6000" erev="50mV"/>
         <ChannelPopulation id="KPop" channel="k" number="1800" erev="-77mV"/>
     </HHCell>
- 
+
     <Component id="gen1" type="spikeGenerator" period="30ms"/>
-
     <Component id="gen2" type="spikeGenerator2" period="32ms"/>
-
-    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS"
-               refractoryPeriod="4ms" capacitance="1pF"/>
+    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS" refractoryPeriod="4ms" capacitance="1pF"/>
 
     <ComponentType name="Display">
-        <Text name="title"/>   
+        <Text name="title"/>
         <Parameter name="xmin" dimension="none"/>
         <Parameter name="xmax" dimension="none"/>
         <Parameter name="ymin" dimension="none"/>
         <Parameter name="ymax" dimension="none"/>
-
         <Parameter name="timeScale" dimension="time"/>
         <Children name="lines" type="Line"/>
-
         <Simulation>
             <DataDisplay title="title" dataRegion="xmin,xmax,ymin,ymax"/>
         </Simulation>
     </ComponentType>
-
 
     <ComponentType name="Line">
         <Parameter name="scale" dimension="*"/>
@@ -49,25 +41,19 @@
         </Simulation>
     </ComponentType>
 
-
     <ComponentType name="Simulation">
         <Parameter name="length" dimension="time"/>
         <Parameter name="step" dimension="time"/>
-    
         <ComponentReference name="target" type="Component"/>
-
-
         <Children name="displays" type="Display"/>
-        
         <Dynamics>
             <StateVariable name="t" dimension="time"/>
         </Dynamics>
-    
         <Simulation>
             <Run component="target" variable="t" increment="step" total="length"/>
         </Simulation>
     </ComponentType>
-    
+
     <Simulation id="sim1" length="80ms" step="0.01ms" target="hhcell_1">
         <Display id="d0" title="Example 6: User defined types for simulation and display" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="60">
             <Line id="V" quantity="v" scale="1mV" timeScale="1ms" color="#0000f0"/>
@@ -75,6 +61,4 @@
             <Line id="K_q" quantity="KPop/geff" scale="1nS" timeScale="1ms" color="#00f000"/>-->
         </Display>
     </Simulation>
-  
-
 </Lems>

--- a/examples/example7.xml
+++ b/examples/example7.xml
@@ -1,37 +1,27 @@
+<?xml version="1.0"?>
 <Lems>
- 
-    <Target component="sim1"/> 
- 
- 
+    <Target component="sim1"/>
+
     <Include file="ex2dims.xml"/>
     <Include file="spikegenerators.xml"/>
     <Include file="misciaf.xml"/>
 
- 
     <Component id="gen1" type="spikeGenerator" period="30ms"/>
-
     <Component id="gen2" type="spikeGenerator2" period="32ms"/>
-
-    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS"
-           refractoryPeriod="4ms" capacitance="1pF"/>
-
+    <Component id="iaf3cpt" type="iaf3" leakReversal="-50mV" deltaV="50mV" threshold="-30mV" leakConductance="50pS" refractoryPeriod="4ms" capacitance="1pF"/>
 
     <ComponentType name="Network">
         <Children name="populations" type="Population"/>
         <Children name="connectivities" type="EventConnectivity"/>
     </ComponentType>
 
-
     <ComponentType name="Population">
         <ComponentReference name="component" type="Component"/>
         <Parameter name="size" dimension="none"/>
-   
         <Structure>
             <MultiInstantiate number="size" component="component"/>
         </Structure>
-  
     </ComponentType>
-
 
     <ComponentType name="EventConnectivity">
         <Link name="source" type="Population"/>
@@ -39,9 +29,7 @@
         <Child name="Connections" type="ConnectionPattern"/>
     </ComponentType>
 
-
     <ComponentType name="ConnectionPattern"/>
-
 
     <ComponentType name="AllAll" extends="ConnectionPattern">
         <Structure>
@@ -49,28 +37,24 @@
                 <ForEach instances="../target" as="b">
                     <EventConnection from="a" to="b"/>
                 </ForEach>
-            </ForEach>    
+            </ForEach>
         </Structure>
     </ComponentType>
-
 
     <Network id="net1">
         <Population id="p1" component="gen1" size="2"/>
         <Population id="p3" component="iaf3cpt" size="3"/>
-     
         <EventConnectivity id="p1-p3" source="p1" target="p3">
             <Connections type="AllAll"/>
         </EventConnectivity>
     </Network>
 
+    <Include file="SingleSimulation.xml"/>
 
-    <Include file="SingleSimulation.xml" />
-    
     <Simulation id="sim1" length="80ms" step="0.05ms" target="net1">
         <Display id="d0" title="Example 7: User defined types for networks and populations" timeScale="1ms" xmin="-10" xmax="90" ymin="-50" ymax="90">
             <Line id="gen_v" quantity="p3[0]/v" scale="1mV" timeScale="1ms" color="#0000f0"/>
             <Line id="gen_tsince" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#00c000"/>
         </Display>
     </Simulation>
-
 </Lems>

--- a/examples/example8.xml
+++ b/examples/example8.xml
@@ -1,12 +1,9 @@
+<?xml version="1.0"?>
 <Lems>
-
-    <Target component="sim1"/> 
-
-
+    <Target component="sim1"/>
     <Include file="ex2dims.xml"/>
     <Include file="spikegenerators.xml"/>
     <Include file="misciaf.xml"/>
-
 
     <ComponentType name="refractiaf">
         <Parameter name="threshold" dimension="voltage"/>
@@ -14,73 +11,58 @@
         <Parameter name="capacitance" dimension="capacitance"/>
         <Parameter name="vleak" dimension="voltage"/>
         <Parameter name="gleak" dimension="conductance"/>
-
         <Parameter name="current" dimension="current"/>
         <Parameter name="vreset" dimension="voltage"/>
         <Parameter name="deltaV" dimension="voltage"/>
         <Parameter name="v0" dimension="voltage"/>
-
         <EventPort name="out" direction="out"/>
         <EventPort name="in" direction="in"/>
-
         <Exposure name="v" dimension="voltage"/>
-
-        <Dynamics>     
-            <StateVariable name="v" exposure="v" dimension="voltage" /> 
-            <StateVariable name="tin" dimension="time"/>       
-            
+        <Dynamics>
+            <StateVariable name="v" exposure="v" dimension="voltage"/>
+            <StateVariable name="tin" dimension="time"/>
             <OnStart>
                 <StateAssignment variable="v" value="v0"/>
             </OnStart>
-
-            <Regime name="refr">         
-                <OnEntry>             
-                    <StateAssignment variable="tin" value="t" />             
-                    <StateAssignment variable="v" value="vreset" />          
-                </OnEntry>                   
-                <OnCondition test="t .gt. tin + refractoryPeriod">                 
-                    <Transition regime="int" />             
-                </OnCondition>         
-            </Regime>          
-
-            <Regime name="int" initial="true">         
-                <TimeDerivative variable="v" value="(current + gleak * (vleak - v)) / capacitance" />         
-                <OnCondition test="v .gt. threshold">             
-                    <EventOut port="out" />             
-                    <Transition regime="refr" />         
-                </OnCondition>         
+            <Regime name="refr">
+                <OnEntry>
+                    <StateAssignment variable="tin" value="t"/>
+                    <StateAssignment variable="v" value="vreset"/>
+                </OnEntry>
+                <OnCondition test="t .gt. tin + refractoryPeriod">
+                    <Transition regime="int"/>
+                </OnCondition>
+            </Regime>
+            <Regime name="int" initial="true">
+                <TimeDerivative variable="v" value="(current + gleak * (vleak - v)) / capacitance"/>
+                <OnCondition test="v .gt. threshold">
+                    <EventOut port="out"/>
+                    <Transition regime="refr"/>
+                </OnCondition>
                 <OnEvent port="in">
                     <StateAssignment variable="v" value="v + deltaV"/>
                 </OnEvent>
-
             </Regime>
         </Dynamics>
 
     </ComponentType>
 
-
     <Component id="gen1" type="spikeGenerator" period="7ms"/>
 
-    
-    <Component id="multiregime" type="refractiaf" threshold="-50mV" v0="-80mV"
-               refractoryPeriod="20ms" capacitance="1pF" vreset="-80mV" vleak="-90mV" 
-               gleak="5pS" current="0.00001nA" deltaV="5mV"/>
-
+    <Component id="multiregime" type="refractiaf" threshold="-50mV" v0="-80mV" refractoryPeriod="20ms" capacitance="1pF" vreset="-80mV" vleak="-90mV" gleak="5pS" current="0.00001nA" deltaV="5mV"/>
 
     <ComponentType name="Network">
         <Children name="populations" type="Population"/>
         <Children name="connectivities" type="EventConnectivity"/>
     </ComponentType>
 
-
     <ComponentType name="Population">
         <ComponentReference name="component" type="Component"/>
         <Parameter name="size" dimension="none"/>
         <Structure>
-                <MultiInstantiate number="size" component="component"/>
+            <MultiInstantiate number="size" component="component"/>
         </Structure>
     </ComponentType>
-
 
     <ComponentType name="EventConnectivity">
         <Link name="source" type="Population"/>
@@ -88,9 +70,7 @@
         <Child name="Connections" type="ConnectionPattern"/>
     </ComponentType>
 
-
     <ComponentType name="ConnectionPattern"/>
-
 
     <ComponentType name="AllAll" extends="ConnectionPattern">
         <Structure>
@@ -98,22 +78,19 @@
                 <ForEach instances="../target" as="b">
                     <EventConnection from="a" to="b"/>
                 </ForEach>
-            </ForEach>    
+            </ForEach>
         </Structure>
     </ComponentType>
-
 
     <Network id="net1">
         <Population id="p1" component="gen1" size="1"/>
         <Population id="p3" component="multiregime" size="2"/>
-
         <EventConnectivity id="p1-p3" source="p1" target="p3">
             <Connections type="AllAll"/>
         </EventConnectivity>
     </Network>
 
-
-    <Include file="SingleSimulation.xml" />
+    <Include file="SingleSimulation.xml"/>
 
     <Simulation id="sim1" length="80ms" step="0.05ms" target="net1">
         <Display id="d0" title="Example 8: Regimes in dynamics definitions" timeScale="1ms" xmin="-10" xmax="90" ymin="-90" ymax="20">
@@ -121,6 +98,4 @@
             <Line id="gen_sv" quantity="p1[0]/tsince" scale="1ms" timeScale="1ms" color="#f00000"/>
         </Display>
     </Simulation>
-
-
 </Lems>

--- a/examples/hhaltgate.xml
+++ b/examples/hhaltgate.xml
@@ -1,24 +1,19 @@
+<?xml version="1.0"?>
 <Lems>
- 
     <ComponentType name="HHGate">
-        <Parameter name="power" dimension="none"/> 
+        <Parameter name="power" dimension="none"/>
         <Child name="Forward" type="HHRate"/>
         <Child name="Reverse" type="HHRate"/>
         <Requirement name="v" dimension="voltage"/>
         <Exposure name="fcond" dimension="none"/>
-    
-   
         <Dynamics simultaneous="false">
             <StateVariable name="x" dimension="none"/>
             <DerivedVariable name="ex" dimension="none" value="exp(x)"/>
             <DerivedVariable name="q" dimension="none" value="ex / (1 + ex)"/>
             <DerivedVariable name="rf" dimension="per_time" select="Forward/r"/>
-            <DerivedVariable name="rr" dimension="per_time" select="Reverse/r"/> 
-        
+            <DerivedVariable name="rr" dimension="per_time" select="Reverse/r"/>
             <TimeDerivative variable="x" value="(1 + ex)^2 / ex * (rf * (1 - q) - rr * q)"/>
-      
             <DerivedVariable name="fcond" dimension="none" exposure="fcond" value="q^power"/>
-        </Dynamics>    
+        </Dynamics>
     </ComponentType>
-
 </Lems>

--- a/examples/hhcell.xml
+++ b/examples/hhcell.xml
@@ -1,12 +1,10 @@
+<?xml version="1.0"?>
 <Lems>
-
     <Include file="hhchannel.xml"/>
-
     <Dimension name="voltage" m="1" l="2" t="-3" i="-1"/>
     <Dimension name="capacitance" m="-1" l="-2" t="4" i="2"/>
     <Dimension name="current" i="1"/>
 
-    
     <ComponentType name="ChannelPopulation">
         <ComponentReference name="channel" type="HHChannel"/>
         <Parameter name="number" dimension="none"/>
@@ -14,19 +12,15 @@
         <Requirement name="v" dimension="voltage"/>
         <Exposure name="current" dimension="current"/>
         <Exposure name="geff" dimension="conductance"/>
-  
         <Structure>
             <ChildInstance component="channel"/>
         </Structure>
-  
         <Dynamics simultaneous="false">
             <DerivedVariable name="channelg" dimension="conductance" select="channel/g"/>
             <DerivedVariable name="geff" exposure="geff" value="channelg * number"/>
             <DerivedVariable name="current" exposure="current" value="geff * (erev - v)"/>
         </Dynamics>
-    
     </ComponentType>
-
 
     <ComponentType name="HHCell">
         <Parameter name="capacitance" dimension="capacitance"/>
@@ -34,16 +28,13 @@
         <Parameter name="injection" dimension="current"/>
         <Parameter name="v0" dimension="voltage"/>
         <Exposure name="v" dimension="voltage"/>
-    
         <Dynamics simultaneous="true">
             <OnStart>
                 <StateAssignment variable="v" value="v0"/>
             </OnStart>
-  
             <DerivedVariable name="totcurrent" dimension="current" select="populations[*]/current" reduce="add"/>
-            <StateVariable name="v" exposure="v" dimension="voltage"/> 
+            <StateVariable name="v" exposure="v" dimension="voltage"/>
             <TimeDerivative variable="v" value="(totcurrent + injection) / capacitance"/>
         </Dynamics>
     </ComponentType>
- 
 </Lems>

--- a/examples/hhchannel.xml
+++ b/examples/hhchannel.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0"?>
 <Lems>
-
     <Dimension name="voltage" m="1" l="2" t="-3" i="-1"/>
     <Dimension name="time" t="1"/>
     <Dimension name="per_time" t="-1"/>
@@ -7,7 +7,6 @@
     <Dimension name="capacitance" m="-1" l="-2" t="4" i="2"/>
     <Dimension name="current" i="1"/>
 
-    
     <ComponentType name="HHRate">
         <Parameter name="rate" dimension="per_time"/>
         <Parameter name="midpoint" dimension="voltage"/>
@@ -16,13 +15,11 @@
         <Exposure name="r" dimension="per_time"/>
     </ComponentType>
 
-
     <ComponentType name="HHExpRate" extends="HHRate">
         <Dynamics>
-            <DerivedVariable name="r" exposure="r"  dimension="per_time" value="rate * exp((v - midpoint)/scale)"/>
+            <DerivedVariable name="r" exposure="r" dimension="per_time" value="rate * exp((v - midpoint)/scale)"/>
         </Dynamics>
     </ComponentType>
-
 
     <ComponentType name="HHSigmoidRate" extends="HHRate">
         <Dynamics>
@@ -30,35 +27,30 @@
         </Dynamics>
     </ComponentType>
 
-
     <ComponentType name="HHExpLinearRate" extends="HHRate">
         <Dynamics>
             <DerivedVariable name="x" dimension="none" value="(v - midpoint) / scale"/>
             <DerivedVariable name="r" dimension="per_time" exposure="r" value="rate * x / (1 - exp(-x))"/>
         </Dynamics>
     </ComponentType>
- 
 
     <ComponentType name="HHGate0">
-        <Parameter name="power" dimension="none"/> 
+        <Parameter name="power" dimension="none"/>
         <Child name="Forward" type="HHRate"/>
         <Child name="Reverse" type="HHRate"/>
         <Requirement name="v" dimension="voltage"/>
         <Exposure name="fcond" dimension="none"/>
-    
         <Dynamics simultaneous="true">
             <StateVariable name="q" dimension="none"/>
             <DerivedVariable dimension="per_time" name="rf" select="Forward/r"/>
-            <DerivedVariable dimension="per_time" name="rr" select="Reverse/r"/> 
+            <DerivedVariable dimension="per_time" name="rr" select="Reverse/r"/>
             <TimeDerivative variable="q" value="rf * (1 - q) - rr * q"/>
             <DerivedVariable name="fcond" dimension="none" exposure="fcond" value="q^power"/>
-        </Dynamics>    
+        </Dynamics>
     </ComponentType>
-
 
     <Include file="hhaltgate.xml"/>
 
-    
     <ComponentType name="HHChannel">
         <Parameter name="conductance" dimension="conductance"/>
         <Children name="gates" type="HHGate"/>
@@ -68,7 +60,4 @@
             <DerivedVariable name="g" exposure="g" dimension="conductance" value="conductance * gatefeff"/>
         </Dynamics>
     </ComponentType>
-
-
 </Lems>
-

--- a/examples/hhmodels.xml
+++ b/examples/hhmodels.xml
@@ -1,23 +1,21 @@
+<?xml version="1.0"?>
 <Lems>
     <Include file="hhchannel.xml"/>
 
-    <Unit symbol="mV" dimension="voltage" power="-3"/> 
+    <Unit symbol="mV" dimension="voltage" power="-3"/>
     <Unit symbol="per_ms" dimension="per_time" power="3"/>
     <Unit symbol="pS" dimension="conductance" power="-12"/>
 
-    
     <HHChannel id="na" conductance="20pS">
         <HHGate id="m" power="3">
             <Forward type="HHExpLinearRate" rate="1.per_ms" midpoint="-40mV" scale="10mV"/>
             <Reverse type="HHExpRate" rate="4per_ms" midpoint="-65mV" scale="-18mV"/>
         </HHGate>
-    
         <HHGate id="h" power="1">
             <Forward type="HHExpRate" rate="0.07per_ms" midpoint="-65.mV" scale="-20.mV"/>
             <Reverse type="HHSigmoidRate" rate="1per_ms" midpoint="-35mV" scale="10mV"/>
         </HHGate>
     </HHChannel>
-
 
     <HHChannel id="k" conductance="20pS">
         <HHGate id="n" power="4">
@@ -25,5 +23,4 @@
             <Reverse type="HHExpRate" rate="0.125per_ms" midpoint="-65mV" scale="-80mV"/>
         </HHGate>
     </HHChannel>
-
 </Lems>

--- a/examples/misciaf.xml
+++ b/examples/misciaf.xml
@@ -1,7 +1,6 @@
+<?xml version="1.0"?>
 <Lems>
-    
     <Include file="elecdims.xml"/>
-   
 
     <ComponentType name="iaf1">
         <Parameter name="threshold" dimension="voltage"/>
@@ -9,24 +8,18 @@
         <Parameter name="capacitance" dimension="capacitance"/>
     </ComponentType>
 
-
     <ComponentType name="iaf3" extends="iaf1">
         <Parameter name="leakConductance" dimension="conductance"/>
         <Parameter name="leakReversal" dimension="voltage"/>
         <Parameter name="deltaV" dimension="voltage"/>
         <EventPort name="spikes-in" direction="in"/>
         <Exposure name="v" dimension="voltage"/>
-
         <Dynamics>
             <StateVariable name="v" exposure="v" dimension="voltage"/>
             <TimeDerivative variable="v" value="leakConductance * (leakReversal - v) / capacitance"/>
-             
             <OnEvent port="spikes-in">
                 <StateAssignment variable="v" value="v + deltaV"/>
-            </OnEvent>      
+            </OnEvent>
         </Dynamics>
-
     </ComponentType>
- 
-
 </Lems>

--- a/examples/spikegenerators.xml
+++ b/examples/spikegenerators.xml
@@ -1,7 +1,6 @@
+<?xml version="1.0"?>
 <Lems>
-
     <Dimension name="time" t="1"/>
- 
 
     <ComponentType name="spikeGenerator">
         <Parameter name="period" dimension="time"/>
@@ -17,7 +16,6 @@
         </Dynamics>
     </ComponentType>
 
-
     <ComponentType name="spikeGenerator2" extends="spikeGenerator">
         <Dynamics>
             <DerivedVariable name="tsince" exposure="tsince" value="t - tlast"/>
@@ -28,6 +26,4 @@
             </OnCondition>
         </Dynamics>
     </ComponentType>
- 
-
 </Lems>


### PR DESCRIPTION
They'll look better on docs.neuroml.org now.

Only formats using xmllint, doesn't change contents at all.